### PR TITLE
Add gem for setting ENV variables 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@
 # Ignore locally installed gems
 /vendor/bundle
 /.idea/*
+
+# Ignore application configuration
+/config/application.yml

--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,8 @@ gem "puma", "~> 5.0"
 # Hotwire's SPA-like page accelerator [https://turbo.hotwired.dev]
 gem "turbo-rails"
 
+gem 'figaro'
+
 # Hotwire's modest JavaScript framework [https://stimulus.hotwired.dev]
 #gem "stimulus-rails"
 # Bootstrap

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,6 +129,8 @@ GEM
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (2.0.1)
     ffi (1.15.5)
+    figaro (1.2.0)
+      thor (>= 0.14.0, < 2)
     formatador (1.1.0)
     gherkin (4.1.3)
     globalid (1.0.0)
@@ -359,6 +361,7 @@ DEPENDENCIES
   database_cleaner (~> 1.8.5)
   debug
   factory_bot_rails
+  figaro
   guard-rspec
   jbuilder (~> 2.10.1)
   omniauth-google-oauth2


### PR DESCRIPTION
This PR adds a gem which easily allows us to set ENV variables locally (I already added them to our heroku app via heroku CLI)

**Everyone: please read carefully and follow the instructions below**
1. Once this PR is merged, within your local environment run `bundle install` & `bundle exec figaro install`
2. Navigate to `config/application.yml`
3. Add the code below to the file:
```
GOOGLE_CLIENT_ID: <secret>
GOOGLE_CLIENT_SECRET: <secret>
```
4. The environment variables are now set for you locally! These will not be pushed to GitHub since they are gitignored 
