### PR TITLE
Privileged Login

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,6 +1,15 @@
 class SessionsController < ApplicationController
 
     def google_auth
+        # Get the official admins
+        admins = ENV['ADMINS']
+        staff = ENV['STAFF']
+        if admins.blank? or staff.blank?
+            redirect_to root_path, flash: { :error => "Something went wrong, please try again later." }
+            return
+        end
+        admins = admins.split(',')
+        staff = staff.split(',')
         # Get access tokens from the google server
         access_token = request.env["omniauth.auth"]
         existing_user = User.where(email: access_token.info.email).present?
@@ -11,16 +20,24 @@ class SessionsController < ApplicationController
         # Note: Refresh_token is only sent once during the first request
         refresh_token = access_token.credentials.refresh_token
         user.google_refresh_token = refresh_token if refresh_token.present?
+        # set appropriate permissions
+        user_is_admin = admins.include? access_token.info.email
+        user_is_staff = staff.include? access_token.info.email
         if existing_user
             session[:current_user_id] = user.id
             redirect_to root_path, flash: { :success => "Success! You've been logged-in!" }
         else
-            user.is_student = true  # new user is a student by default
+            user.is_student = (!user_is_admin and !user_is_staff)
+            user.is_admin = user_is_admin
+            user.is_staff = user_is_staff
             if user.save
                 if user.is_student
                     session[:current_user_id] = user.id
                     redirect_to login_confirm_path
-                else
+                elsif user.is_admin
+                    session[:current_user_id] = user.id
+                    redirect_to root_path, flash: { :success => "Success! You've been logged-in!" }
+                else # user must be staff
                     session[:current_user_id] = user.id
                     redirect_to root_path, flash: { :success => "Success! You've been logged-in!" }
                 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -6,6 +6,9 @@ require "active_support/core_ext/integer/time"
 # and recreated between test runs. Don't rely on the data there!
 
 Rails.application.configure do
+  # set testing ENV variables
+  ENV["ADMINS"] = "google_admin@berkeley.edu"
+  ENV["STAFF"] = "google_staff@berkeley.edu"
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Turn false under Spring and add config.action_view.cache_template_loading = true.

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -5,7 +5,7 @@ Rails.application.config.middleware.use OmniAuth::Builder do
       :google_oauth2,
       {
         "provider" => 'google_oauth2',
-        "uid" =>      '100000000000000000000',
+        "uid" =>      '1000000000',
         "info" =>     {
           "name" =>       'Google Test Developer',
           "email" =>      'google_test@berkeley.edu',

--- a/features/checkin_sad_path.feature
+++ b/features/checkin_sad_path.feature
@@ -2,7 +2,7 @@ Feature: checkin sad path
 
     As a non student, I won't be able to see button to checkin page
 
-#Scenario: only student can checkin (admin can't access this feature)
-#    Given I logged in as a "Admin"
-#    And I am on the landing page
-#    Then I should not got "Check-in"
+Scenario: only student can checkin (admin can't access this feature)
+    Given I logged in as a "Admin"
+    And I am on the landing page
+    Then I should not got "Check-in"

--- a/features/log_in.feature
+++ b/features/log_in.feature
@@ -5,12 +5,13 @@ Feature: Log in as different type of user
 
 Background: logged out user, on landing page (never logged in before)
     Given I am on the landing page
+    And I am a logged-out "Student"
 
 Scenario: student should be able to log in
     Then I should got "Login with Google"
 
 Scenario: prompt to input more personal info only at first time log in
-    When I click "Login with Google" 
+    When I click "Login with Google"
     Then I should be on the confirm page
     And I should see "Please Verify All the information below"
 
@@ -35,8 +36,8 @@ Scenario: clicking submit without filling out all fields in confirm page (sad pa
     When I click "Submit"
     Then I should be on the confirm page
 
-#Scenario: logging in as admin should direct to admin dashboard
-#    When I am a "Admin"
-#    And I click "Login with Google"
-#    Then I should be on the landing page
-#    And I should got "admin dashboard"
+Scenario: logging in as admin should direct to admin dashboard
+    When I am a "Admin"
+    And I click "Login with Google"
+    Then I should be on the landing page
+    And I should got "admin dashboard"

--- a/features/nav_to_admin_dashboard.feature
+++ b/features/nav_to_admin_dashboard.feature
@@ -6,9 +6,9 @@ Background: logged in admin, on landing page
     Given I logged in as a "Admin"
     And I am on the landing page
 
-#Scenario: admin should see a link to admin dashboard
-#    Then I should got "Go to admin dashboard"
-#
-#Scenario: admin should be able to follow the link and go to the admin dashboard
-#    When I click "Go to admin dashboard"
-#    Then I should be on the admin dashboard
+Scenario: admin should see a link to admin dashboard
+    Then I should got "Go to admin dashboard"
+
+Scenario: admin should be able to follow the link and go to the admin dashboard
+    When I click "Go to admin dashboard"
+    Then I should be on the admin dashboard

--- a/features/step_definitions/login_steps.rb
+++ b/features/step_definitions/login_steps.rb
@@ -7,12 +7,49 @@ Given /^(?:|I )logged in as a "([^"]*)"$/ do |user_type|
 end
 
 When /^(?:|I )am a "([^"]*)"$/ do |user_type|
-  u = User.new(first_name: 'Google', last_name: 'Test Developer', email: 'google_test@example.com')
   if user_type == 'Student'
+    OmniAuth.config.add_mock(
+      :google_oauth2,
+      {
+        "provider" => 'google_oauth2',
+        "uid" =>      '1000000000',
+        "info" =>     {
+          "name" =>       'Google Test Developer',
+          "email" =>      'google_test@berkeley.edu',
+          "first_name" => 'Google',
+          "last_name" =>  'Test Developer'
+        },
+        "credentials" => {
+          "token" => "credentials_token_1234567",
+          "refresh_token" => "credentials_refresh_token_45678"
+        }
+      }
+    )
+    u = User.new(first_name: 'Google', last_name: 'Test Developer', email: 'google_test@berkeley.edu')
     u.is_student = true
   elsif user_type == 'Admin'
+    OmniAuth.config.add_mock(
+      :google_oauth2,
+      {
+        "provider" => 'google_oauth2',
+        "uid" =>      '1000000000',
+        "info" =>     {
+          "name" =>       'Google Admin Developer',
+          "email" =>      'google_admin@berkeley.edu',
+          "first_name" => 'Google',
+          "last_name" =>  'Admin Developer'
+        },
+        "credentials" => {
+          "token" => "credentials_token_1234567",
+          "refresh_token" => "credentials_refresh_token_45678"
+        }
+      }
+    )
+    u = User.new(first_name: 'Google', last_name: 'Admin Developer', email: 'google_admin@berkeley.edu')
     u.is_admin = true
   elsif user_type == 'Staff'
+    # pending
+    u = User.new(first_name: 'Google', last_name: 'Test Developer', email: 'google_staff@berkeley.edu')
     u.is_staff = true
   end
   u.save
@@ -23,4 +60,44 @@ When /^(?:|I )log in$/ do
     When I am on the landing page
     When I click "Login with Google"
   }
+end
+
+And(/^I am a logged-out "([^"]*)"$/) do |user_type|
+  if user_type == 'Student'
+    OmniAuth.config.add_mock(
+      :google_oauth2,
+      {
+        "provider" => 'google_oauth2',
+        "uid" =>      '1000000000',
+        "info" =>     {
+          "name" =>       'Google Test Developer',
+          "email" =>      'google_test@berkeley.edu',
+          "first_name" => 'Google',
+          "last_name" =>  'Test Developer'
+        },
+        "credentials" => {
+          "token" => "credentials_token_1234567",
+          "refresh_token" => "credentials_refresh_token_45678"
+        }
+      }
+    )
+  elsif user_type == 'Admin'
+    OmniAuth.config.add_mock(
+      :google_oauth2,
+      {
+        "provider" => 'google_oauth2',
+        "uid" =>      '1000000000',
+        "info" =>     {
+          "name" =>       'Google Admin Developer',
+          "email" =>      'google_admin@berkeley.edu',
+          "first_name" => 'Google',
+          "last_name" =>  'Admin Developer'
+        },
+        "credentials" => {
+          "token" => "credentials_token_1234567",
+          "refresh_token" => "credentials_refresh_token_45678"
+        }
+      }
+    )
+  end
 end

--- a/features/step_definitions/login_steps.rb
+++ b/features/step_definitions/login_steps.rb
@@ -1,3 +1,33 @@
+ADMIN_CREDENTIALS = {
+  "provider" => 'google_oauth2',
+  "uid" =>      '1000000000',
+  "info" =>     {
+    "name" =>       'Google Admin Developer',
+    "email" =>      'google_admin@berkeley.edu',
+    "first_name" => 'Google',
+    "last_name" =>  'Admin Developer'
+  },
+  "credentials" => {
+    "token" => "credentials_token_1234567",
+    "refresh_token" => "credentials_refresh_token_45678"
+  }
+}
+
+STUDENT_CREDENTIALS = {
+  "provider" => 'google_oauth2',
+  "uid" =>      '1000000000',
+  "info" =>     {
+    "name" =>       'Google Test Developer',
+    "email" =>      'google_test@berkeley.edu',
+    "first_name" => 'Google',
+    "last_name" =>  'Test Developer'
+  },
+  "credentials" => {
+    "token" => "credentials_token_1234567",
+    "refresh_token" => "credentials_refresh_token_45678"
+  }
+}
+
 Given /^(?:|I )logged in as a "([^"]*)"$/ do |user_type|
   # need to clear/delete previous created record in database before inserting
   steps %Q{
@@ -10,40 +40,14 @@ When /^(?:|I )am a "([^"]*)"$/ do |user_type|
   if user_type == 'Student'
     OmniAuth.config.add_mock(
       :google_oauth2,
-      {
-        "provider" => 'google_oauth2',
-        "uid" =>      '1000000000',
-        "info" =>     {
-          "name" =>       'Google Test Developer',
-          "email" =>      'google_test@berkeley.edu',
-          "first_name" => 'Google',
-          "last_name" =>  'Test Developer'
-        },
-        "credentials" => {
-          "token" => "credentials_token_1234567",
-          "refresh_token" => "credentials_refresh_token_45678"
-        }
-      }
+      STUDENT_CREDENTIALS
     )
     u = User.new(first_name: 'Google', last_name: 'Test Developer', email: 'google_test@berkeley.edu')
     u.is_student = true
   elsif user_type == 'Admin'
     OmniAuth.config.add_mock(
       :google_oauth2,
-      {
-        "provider" => 'google_oauth2',
-        "uid" =>      '1000000000',
-        "info" =>     {
-          "name" =>       'Google Admin Developer',
-          "email" =>      'google_admin@berkeley.edu',
-          "first_name" => 'Google',
-          "last_name" =>  'Admin Developer'
-        },
-        "credentials" => {
-          "token" => "credentials_token_1234567",
-          "refresh_token" => "credentials_refresh_token_45678"
-        }
-      }
+      ADMIN_CREDENTIALS
     )
     u = User.new(first_name: 'Google', last_name: 'Admin Developer', email: 'google_admin@berkeley.edu')
     u.is_admin = true
@@ -66,38 +70,12 @@ And(/^I am a logged-out "([^"]*)"$/) do |user_type|
   if user_type == 'Student'
     OmniAuth.config.add_mock(
       :google_oauth2,
-      {
-        "provider" => 'google_oauth2',
-        "uid" =>      '1000000000',
-        "info" =>     {
-          "name" =>       'Google Test Developer',
-          "email" =>      'google_test@berkeley.edu',
-          "first_name" => 'Google',
-          "last_name" =>  'Test Developer'
-        },
-        "credentials" => {
-          "token" => "credentials_token_1234567",
-          "refresh_token" => "credentials_refresh_token_45678"
-        }
-      }
+      STUDENT_CREDENTIALS
     )
   elsif user_type == 'Admin'
     OmniAuth.config.add_mock(
       :google_oauth2,
-      {
-        "provider" => 'google_oauth2',
-        "uid" =>      '1000000000',
-        "info" =>     {
-          "name" =>       'Google Admin Developer',
-          "email" =>      'google_admin@berkeley.edu',
-          "first_name" => 'Google',
-          "last_name" =>  'Admin Developer'
-        },
-        "credentials" => {
-          "token" => "credentials_token_1234567",
-          "refresh_token" => "credentials_refresh_token_45678"
-        }
-      }
+      ADMIN_CREDENTIALS
     )
   end
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -43,7 +43,6 @@ begin
 rescue NameError
   raise "You need to add database_cleaner to your Gemfile (in the :test group) if you wish to use it."
 end
-
 # You may also want to configure DatabaseCleaner to use different strategies for certain features and scenarios.
 # See the DatabaseCleaner documentation for details. Example:
 #


### PR DESCRIPTION
This PR adds logic to enable predetermined admins & staff to log in and be given the appropriate permissions. This is achieved by manually setting environment variables for admins and staff (`ENV["ADMINS]` & `ENV["STAFF"]`) which are both comma-separated lists of Berkeley Gmail addresses associated with the admin or staff member. In order to test this functionality, you must locally add yourself as an admin by creating an environment variable like so: 

`ENV["ADMINS"]=your_gmail@berkeley.edu`
`ENV["STAFF"]=something`
**both of these variables must be set or else the sessions_controller will error out!**

Once this is merged, we will add the official environment variables with names of admin/staff to heroku. 